### PR TITLE
Add FreeBird.jl to Other Packages section

### DIFF
--- a/index.md
+++ b/index.md
@@ -65,6 +65,8 @@ We also feature a few packages for
 Some other packages for molecular and materials modelling worth mentioning:
 - [Wannier.jl](https://github.com/qiaojunfeng/Wannier.jl):
   Wannier localisation of electronic structures
+- [FreeBird.jl](https://github.com/wexlergroup/FreeBird.jl):
+  Free energy calculators by Bayesian-inspired nested sampling and other integration techniques.
 
 ## Contacting us
 [zulip-url]: https://juliamolsim.zulipchat.com/register/


### PR DESCRIPTION
Added FreeBird.jl package information to the index. As FreeBird.jl is not yet under the JuliaMolSim umbrella, but heavily uses several JuliaMolSim packages, I think it's appropriate to list it under the "Other Packages" section.