### PR TITLE
Update menu and add JuliaCon 2025 minisymposium details

### DIFF
--- a/_layout/menu.html
+++ b/_layout/menu.html
@@ -5,6 +5,7 @@
       <div class="menu-item {{ispage index.html}}link{{end}}"><a href="/">Home</a></div>
       <div class="menu-item {{ispage molssi_workshop/index.html}}link{{end}}"><a href="/molssi_workshop" class="menu-list-link">MolSSI workshop</a></div>
       <div class="menu-item {{ispage juliacon21/index.html}}link{{end}}"><a href="/juliacon21" class="menu-list-link">JuliaCon 2021</a></div>
-	  <div class="menu-item {{ispage juliacon22/index.html}}link{{end}}"><a href="/juliacon22" class="menu-list-link">JuliaCon 2022</a></div>
+	    <div class="menu-item {{ispage juliacon22/index.html}}link{{end}}"><a href="/juliacon22" class="menu-list-link">JuliaCon 2022</a></div>
+      <div class="menu-item {{ispage juliacon25/index.html}}link{{end}}"><a href="/juliacon25" class="menu-list-link">JuliaCon 2025</a></div>
     </aside>
     <div class="layout-content">

--- a/juliacon25.md
+++ b/juliacon25.md
@@ -1,0 +1,28 @@
+# JuliaCon 2025 Minisymposium \label{juliacon25}
+
+At JuliaCon Global 2025, we hosted an incredible Computational Chemistry and Materials Science Minisymposium, spanning topics from fundamental theory to cutting-edge applications. The minisymposium took place on July 25 at Lawrence Room 121 (Struct Room) at the University of Pittsburgh. You can view the recording [here](https://www.youtube.com/live/-1ZkdVs2zko?si=CtaWkWX2ujl0c9a1).
+
+## Talks
+🎤 Leticia Madureira (Carnegie Mellon University) — Computational Quantum Chemistry with Sparse Matrix Algorithms
+
+🎤 Shuhei Ohno (Yokohama City University & RIKEN) — Quantum Mechanical Two-Body Problems in Julia
+
+🎤 Lukas Weber (Flatiron Institute) — Carlo.jl: High-Performance Monte Carlo Simulations in Julia
+
+🎤 Haina Wang (University of Pennsylvania) — ElasticNetworks.jl: A Package for Metamaterial Research & Design
+
+🎤 Benjamin Cohen-Stead (University of Tennessee, Knoxville) — Simulating Strongly-Correlated Material Models
+
+🎤 Henry Snowden (University of Warwick) — Simulation of Light-Driven Hot Carrier Dynamics & Transport
+
+🎤 Weishi Wang (Dartmouth College) — Quiqbox.jl 0.6: Basis Design for Electronic Structure and Beyond
+
+🎤 Ray Yang (Washington University in St. Louis) — FreeBird.jl: An Extensible Toolbox for Surface Phase Equilibria
+
+🎤 Jonathan Salmerón-Hernández (New York University) — Liquid Crystal Modeling: Thermodynamics & Numerical Methods
+
+🎤 Qi Zhang (University of Texas at Austin) — Accelerating Fermi Operator Expansion: ML-Inspired Methods
+
+🎤 Henry Snowden (University of Warwick) — NQCDynamics.jl: Nonadiabatic Quantum Classical Dynamics in Julia
+
+We would like to thank our supporting partners, Carnegie Mellon University Department of Chemistry and Department of Materials Science and Engineering, as well as all the speakers and attendees who made this minisymposium a success!


### PR DESCRIPTION
Added a page for the 2025 edition! Will add links to individual videos once they all become available on YT.