### PR TITLE
Updated 2026 info; added YouTube video links to 2025 talks

### DIFF
--- a/_layout/menu.html
+++ b/_layout/menu.html
@@ -5,6 +5,7 @@
       <div class="menu-item {{ispage index.html}}link{{end}}"><a href="/">Home</a></div>
       <div class="menu-item {{ispage molssi_workshop/index.html}}link{{end}}"><a href="/molssi_workshop" class="menu-list-link">MolSSI workshop</a></div>
       <div class="menu-item {{ispage juliacon21/index.html}}link{{end}}"><a href="/juliacon21" class="menu-list-link">JuliaCon 2021</a></div>
-	  <div class="menu-item {{ispage juliacon22/index.html}}link{{end}}"><a href="/juliacon22" class="menu-list-link">JuliaCon 2022</a></div>
+	    <div class="menu-item {{ispage juliacon22/index.html}}link{{end}}"><a href="/juliacon22" class="menu-list-link">JuliaCon 2022</a></div>
+      <div class="menu-item {{ispage juliacon25/index.html}}link{{end}}"><a href="/juliacon25" class="menu-list-link">JuliaCon 2025</a></div>
     </aside>
     <div class="layout-content">

--- a/_layout/menu.html
+++ b/_layout/menu.html
@@ -7,5 +7,7 @@
       <div class="menu-item {{ispage juliacon21/index.html}}link{{end}}"><a href="/juliacon21" class="menu-list-link">JuliaCon 2021</a></div>
 	    <div class="menu-item {{ispage juliacon22/index.html}}link{{end}}"><a href="/juliacon22" class="menu-list-link">JuliaCon 2022</a></div>
       <div class="menu-item {{ispage juliacon25/index.html}}link{{end}}"><a href="/juliacon25" class="menu-list-link">JuliaCon 2025</a></div>
+      <div class="menu-item {{ispage juliacon26/index.html}}link{{end}}"><a href="/juliacon26" class="menu-list-link">JuliaCon 2026</a></div>
+
     </aside>
     <div class="layout-content">

--- a/juliacon25.md
+++ b/juliacon25.md
@@ -1,0 +1,28 @@
+# JuliaCon 2025 Minisymposium \label{juliacon25}
+
+At JuliaCon Global 2025, we hosted an incredible Computational Chemistry and Materials Science Minisymposium, spanning topics from fundamental theory to cutting-edge applications. The minisymposium took place on July 25 at Lawrence Room 121 (Struct Room) at the University of Pittsburgh. You can view the recording [here](https://www.youtube.com/live/-1ZkdVs2zko?si=CtaWkWX2ujl0c9a1).
+
+## Talks
+🎤 Leticia Madureira (Carnegie Mellon University) — Computational Quantum Chemistry with Sparse Matrix Algorithms
+
+🎤 Shuhei Ohno (Yokohama City University & RIKEN) — Quantum Mechanical Two-Body Problems in Julia
+
+🎤 Lukas Weber (Flatiron Institute) — Carlo.jl: High-Performance Monte Carlo Simulations in Julia
+
+🎤 Haina Wang (University of Pennsylvania) — ElasticNetworks.jl: A Package for Metamaterial Research & Design
+
+🎤 Benjamin Cohen-Stead (University of Tennessee, Knoxville) — Simulating Strongly-Correlated Material Models
+
+🎤 Henry Snowden (University of Warwick) — Simulation of Light-Driven Hot Carrier Dynamics & Transport
+
+🎤 Weishi Wang (Dartmouth College) — Quiqbox.jl 0.6: Basis Design for Electronic Structure and Beyond
+
+🎤 Ray Yang (Washington University in St. Louis) — FreeBird.jl: An Extensible Toolbox for Surface Phase Equilibria
+
+🎤 Jonathan Salmerón-Hernández (New York University) — Liquid Crystal Modeling: Thermodynamics & Numerical Methods
+
+🎤 Qi Zhang (University of Texas at Austin) — Accelerating Fermi Operator Expansion: ML-Inspired Methods
+
+🎤 Henry Snowden (University of Warwick) — NQCDynamics.jl: Nonadiabatic Quantum Classical Dynamics in Julia
+
+We would like to thank our supporting partners, Carnegie Mellon University Department of Chemistry and Department of Materials Science and Engineering, as well as all the speakers and attendees who made this minisymposium a success!

--- a/juliacon25.md
+++ b/juliacon25.md
@@ -1,28 +1,28 @@
 # JuliaCon 2025 Minisymposium \label{juliacon25}
 
-At JuliaCon Global 2025, we hosted an incredible Computational Chemistry and Materials Science Minisymposium, spanning topics from fundamental theory to cutting-edge applications. The minisymposium took place on July 25 at Lawrence Room 121 (Struct Room) at the University of Pittsburgh. You can view the recording [here](https://www.youtube.com/live/-1ZkdVs2zko?si=CtaWkWX2ujl0c9a1).
+At JuliaCon Global 2025, we hosted an incredible Computational Chemistry and Materials Science Minisymposium, spanning topics from fundamental theory to cutting-edge applications. The minisymposium took place on July 25 at Lawrence Room 121 (Struct Room) at the University of Pittsburgh. You can view the recorded talks on YouTube by clicking on the links.
 
 ## Talks
-🎤 Leticia Madureira (Carnegie Mellon University) — Computational Quantum Chemistry with Sparse Matrix Algorithms
+🎤 Leticia Madureira (Carnegie Mellon University) — [Computational Quantum Chemistry with Sparse Matrix Algorithms](https://youtu.be/pT67NG8asEY?si=0PwV-UU1lIBC2JpZ)
 
-🎤 Shuhei Ohno (Yokohama City University & RIKEN) — Quantum Mechanical Two-Body Problems in Julia
+🎤 Shuhei Ohno (Yokohama City University & RIKEN) — [Quantum Mechanical Two-Body Problems in Julia](https://youtu.be/HyuhuJcC0eo?si=cjCP4krRCtV1Zfb7)
 
-🎤 Lukas Weber (Flatiron Institute) — Carlo.jl: High-Performance Monte Carlo Simulations in Julia
+🎤 Lukas Weber (Flatiron Institute) — [Carlo.jl: High-Performance Monte Carlo Simulations in Julia](https://youtu.be/6RfvWcKVPWU?si=G-CvgubnbQrs61_u)
 
-🎤 Haina Wang (University of Pennsylvania) — ElasticNetworks.jl: A Package for Metamaterial Research & Design
+🎤 Haina Wang (University of Pennsylvania) — [ElasticNetworks.jl: A Package for Metamaterial Research & Design](https://youtu.be/QZHwGLLCBLY?si=M-7aA52HJkPvlTRN)
 
-🎤 Benjamin Cohen-Stead (University of Tennessee, Knoxville) — Simulating Strongly-Correlated Material Models
+🎤 Benjamin Cohen-Stead (University of Tennessee, Knoxville) — [Simulating Strongly-Correlated Material Models](https://youtu.be/mUJqDbTprDY?si=JtCK0PquQWeGmdGI)
 
-🎤 Henry Snowden (University of Warwick) — Simulation of Light-Driven Hot Carrier Dynamics & Transport
+🎤 Henry Snowden (University of Warwick) — [Simulation of Light-Driven Hot Carrier Dynamics & Transport](https://youtu.be/PecEL44pido?si=fZniGFtURWZbMJ4V)
 
-🎤 Weishi Wang (Dartmouth College) — Quiqbox.jl 0.6: Basis Design for Electronic Structure and Beyond
+🎤 Weishi Wang (Dartmouth College) — [Quiqbox.jl 0.6: Basis Design for Electronic Structure and Beyond](https://youtu.be/jcwAX2cLKoc?si=cv4I4cUUcJpoW06Y)
 
-🎤 Ray Yang (Washington University in St. Louis) — FreeBird.jl: An Extensible Toolbox for Surface Phase Equilibria
+🎤 Ray Yang (Washington University in St. Louis) — [FreeBird.jl: An Extensible Toolbox for Surface Phase Equilibria](https://youtu.be/MWQc35he8K4?si=Qcep-X_LWIVtJQ1z)
 
-🎤 Jonathan Salmerón-Hernández (New York University) — Liquid Crystal Modeling: Thermodynamics & Numerical Methods
+🎤 Jonathan Salmerón-Hernández (New York University) — [Liquid Crystal Modeling: Thermodynamics & Numerical Methods](https://youtu.be/ZuCHbhhp2-4?si=Em9yWj2VGVIoRerL)
 
-🎤 Qi Zhang (University of Texas at Austin) — Accelerating Fermi Operator Expansion: ML-Inspired Methods
+🎤 Qi Zhang (University of Texas at Austin) — [Accelerating Fermi Operator Expansion: ML-Inspired Methods](https://youtu.be/rUsnDH_kwOk?si=0yWppkU5XuY5RoDb)
 
-🎤 Henry Snowden (University of Warwick) — NQCDynamics.jl: Nonadiabatic Quantum Classical Dynamics in Julia
+🎤 Henry Snowden (University of Warwick) — [NQCDynamics.jl: Nonadiabatic Quantum Classical Dynamics in Julia](https://youtu.be/oM5_k82oviU?si=iSwsX5_tSrWOFNQy)
 
 We would like to thank our supporting partners, Carnegie Mellon University Department of Chemistry and Department of Materials Science and Engineering, as well as all the speakers and attendees who made this minisymposium a success!

--- a/juliacon26.md
+++ b/juliacon26.md
@@ -1,0 +1,28 @@
+# JuliaCon 2026 Minisymposium \label{juliacon26}
+
+Julia Global 2026 is taking place in Mainz, Germany. It will feature the JuliaMolSim Minisymposium on **Thursday afternoon, August 13**. 
+
+Here is a list of confirmed talks, you can click on the links to see more details about the speaker/talk on Pretalx. You can also view them on the [JuliaCon 2026 full schedule](https://pretalx.com/juliacon-2026/schedule/) by selecting the JuliaMolSim Minisymposium track. 
+
+See you in Mainz!
+
+## Schedule (Thursday, August 13)
+14:30–15:00 🎤 [Charlotte Rickert](https://pretalx.com/juliacon-2026/speaker/WFL8DE/), [Daniel Kats](https://pretalx.com/juliacon-2026/speaker/SFA7LB/) — [ElemCo.jl: A Julia Package for Electron Correlation in Molecules and Materials](https://pretalx.com/juliacon-2026/talk/THBSKY/)
+
+15:00–15:30 🎤 [Alexander Spears](https://pretalx.com/juliacon-2026/speaker/TEQD9C/) — [ML-accelerated simulation of laser-driven hydrogen evolution with NQCDynamics.jl – Julia and Python in harmony?](https://pretalx.com/juliacon-2026/talk/BLZJJW/)
+
+15:30–16:00 🎤 [Noé Blassel](https://pretalx.com/juliacon-2026/speaker/7JBA9S/) — [Computing transport coefficients using Molly.jl](https://pretalx.com/juliacon-2026/talk/GXPBHY/)
+
+16:00–16:15 🎤 [Hiroharu Sugawara](https://pretalx.com/juliacon-2026/speaker/K3MXFP/) — [BoltzTraP.jl: Thermoelectric transport for the Julia DFT ecosystem](https://pretalx.com/juliacon-2026/talk/SEDPHP/)
+
+16:15–16:30 🎤 [Bruno Ploumhans](https://pretalx.com/juliacon-2026/speaker/PLZXRD/) — [Algorithmic differentiation and error control with DFTK](https://pretalx.com/juliacon-2026/talk/ZLZ8FJ/)
+
+16:30–16:45 🎤 [Henry Snowden](https://pretalx.com/juliacon-2026/speaker/C83CVK/) — [Simulation of light-driven hot carrier dynamics & transport](https://pretalx.com/juliacon-2026/talk/ZPDSRG/)
+
+16:45–17:00 🎤 [Matt Larkin](https://pretalx.com/juliacon-2026/speaker/EEZD99/) — [NQCDynamics.jl: A molecular dynamics platform for non-adiabatic systems](https://pretalx.com/juliacon-2026/talk/ATP8YV/) 
+
+17:00–17:15 🎤 [Ash Baldwin](https://pretalx.com/juliacon-2026/speaker/3RAACY/) — [QCEngine.jl: Electronic Structure for Nonadiabatic Dynamics](https://pretalx.com/juliacon-2026/talk/7VLXGG/)
+
+17:15–17:30 🎤 [Michael F. Herbst](https://pretalx.com/juliacon-2026/speaker/DZ7WHZ/) — [Extending DFTK.jl's features, but not its code complexity](https://pretalx.com/juliacon-2026/talk/ZKCBJY/)
+
+The JuliaCon poster session is in the same evening, and several JuliaMolSIm speakers will present their package(s) there!

--- a/juliacon26.md
+++ b/juliacon26.md
@@ -6,7 +6,7 @@ Here is a list of confirmed talks, you can click on the links to see more detail
 
 See you in Mainz!
 
-## Schedule (Thursday, August 13)
+## Schedule (Thursday, August 13, Room: **Muschel — N2**)
 14:30–15:00 🎤 [Charlotte Rickert](https://pretalx.com/juliacon-2026/speaker/WFL8DE/), [Daniel Kats](https://pretalx.com/juliacon-2026/speaker/SFA7LB/) — [ElemCo.jl: A Julia Package for Electron Correlation in Molecules and Materials](https://pretalx.com/juliacon-2026/talk/THBSKY/)
 
 15:00–15:30 🎤 [Alexander Spears](https://pretalx.com/juliacon-2026/speaker/TEQD9C/) — [ML-accelerated simulation of laser-driven hydrogen evolution with NQCDynamics.jl – Julia and Python in harmony?](https://pretalx.com/juliacon-2026/talk/BLZJJW/)
@@ -25,4 +25,14 @@ See you in Mainz!
 
 17:15–17:30 🎤 [Michael F. Herbst](https://pretalx.com/juliacon-2026/speaker/DZ7WHZ/) — [Extending DFTK.jl's features, but not its code complexity](https://pretalx.com/juliacon-2026/talk/ZKCBJY/)
 
-The JuliaCon poster session is in the same evening, and several JuliaMolSIm speakers will present their package(s) there!
+The JuliaCon poster session is in the same evening, and several JuliaMolSIm speakers will present their package(s) there! Please see the list on [JuliaCon 2026 website](https://juliacon.org/2026/posters/).
+
+On Friday, there is a block of closely related talks in the General track, at room **Muschel — N1**:
+
+15:00–15:15 🎤 [Nathan Zimmerberg](https://pretalx.com/juliacon-2026/speaker/TL7PTK/) - [What’s new with MEDYAN.jl: A Coarse-Grained Cytoskeleton Simulator](https://pretalx.com/juliacon-2026/talk/KGR8N9/)
+
+15:15–15:30 🎤 [Benoît Richard](https://pretalx.com/juliacon-2026/speaker/GZQBUC/) - [Building a Coulomb explosion simulation on top of DifferentialEquations.jl](https://pretalx.com/juliacon-2026/talk/GJRCSK/)
+
+[Coffee Break]
+
+15:45–16:00 🎤 [Fabian Pieck](https://pretalx.com/juliacon-2026/speaker/HAKD78/) - [RandomSequentialAdsorption.jl - Modeling Adsorbate Packing in Area-Selective Atomic Layer Deposition](https://pretalx.com/juliacon-2026/talk/FDVTJJ/)


### PR DESCRIPTION
Added talks submitted to JuliaMolSim but got upgraded into General. Update Room info for 2026. Also added the YT video links for 2025 talks.